### PR TITLE
Saved idx files to output folder

### DIFF
--- a/megatron/data/biencoder_dataset_utils.py
+++ b/megatron/data/biencoder_dataset_utils.py
@@ -135,8 +135,7 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         max_num_samples = np.iinfo(np.int64).max - 1
 
     # Filename of the index mapping
-    data_prefix_file_name = Path(data_prefix).name
-    indexmap_filename = data_prefix_file_name
+    indexmap_filename = Path(data_prefix).name 
     indexmap_filename += '_{}_indexmap'.format(name)
     if num_epochs != (np.iinfo(np.int32).max - 1):
         indexmap_filename += '_{}ep'.format(num_epochs)
@@ -148,13 +147,13 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         indexmap_filename += '_1sentok'
     indexmap_filename += '.npy'
 
-    indexmap_file_path = str(Path(get_args().save).joinpath(indexmap_filename).absolute())
+    indexmap_filename = Path(get_args().save).joinpath(indexmap_filename).resolve()
 
     # Build the indexed mapping if not exist.
     if mpu.get_data_parallel_rank() == 0 and \
-            not os.path.isfile(indexmap_file_path):
+            not os.path.isfile(indexmap_filename):
         print(' > WARNING: could not find index map file {}, building '
-              'the indices on rank 0 ...'.format(indexmap_file_path))
+              'the indices on rank 0 ...'.format(indexmap_filename))
 
         # Make sure the types match the helpers input types.
         assert block_dataset.doc_idx.dtype == np.int64
@@ -180,9 +179,9 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
 
 
         print_rank_0(' > done building samples index mapping')
-        np.save(indexmap_file_path, mapping_array, allow_pickle=True)
+        np.save(indexmap_filename, mapping_array, allow_pickle=True)
         print_rank_0(' > saved the index mapping in {}'.format(
-            indexmap_file_path))
+            indexmap_filename))
         # Make sure all the ranks have built the mapping
         print_rank_0(' > elapsed time to build and save samples mapping '
                      '(seconds): {:4f}'.format(
@@ -198,10 +197,10 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(
-        indexmap_file_path))
+        indexmap_filename))
     start_time = time.time()
 
-    mapping_array = np.load(indexmap_file_path, allow_pickle=True, mmap_mode='r')
+    mapping_array = np.load(indexmap_filename, allow_pickle=True, mmap_mode='r')
     samples_mapping = BlockSamplesMapping(mapping_array)
 
     print_rank_0('    loaded indexed file in {:3.3f} seconds'.format(

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -651,8 +651,7 @@ def get_samples_mapping(indexed_dataset,
         max_num_samples = np.iinfo(np.int64).max - 1
 
     # Filename of the index mapping
-    data_prefix_file_name = Path(data_prefix).name
-    indexmap_filename = data_prefix_file_name
+    indexmap_filename = Path(data_prefix).name
     indexmap_filename += '_{}_indexmap'.format(name)
     if num_epochs != (np.iinfo(np.int32).max - 1):
         indexmap_filename += '_{}ep'.format(num_epochs)
@@ -663,13 +662,13 @@ def get_samples_mapping(indexed_dataset,
     indexmap_filename += '_{}s'.format(seed)
     indexmap_filename += '.npy'
 
-    indexmap_file_path = str(Path(get_args().save).joinpath(indexmap_filename).absolute())
+    indexmap_filename = Path(get_args().save).joinpath(indexmap_filename).resolve()
 
     # Build the indexed mapping if not exist.
     if torch.distributed.get_rank() == 0 and \
-       not os.path.isfile(indexmap_file_path):
+       not os.path.isfile(indexmap_filename):
         print(' > WARNING: could not find index map file {}, building '
-              'the indices on rank 0 ...'.format(indexmap_file_path))
+              'the indices on rank 0 ...'.format(indexmap_filename))
 
         # Make sure the types match the helpers input types.
         assert indexed_dataset.doc_idx.dtype == np.int64
@@ -693,10 +692,9 @@ def get_samples_mapping(indexed_dataset,
             verbose,
             2 if binary_head else 1)
         print_rank_0(' > done building sapmles index maping')
-
-        np.save(indexmap_file_path, samples_mapping, allow_pickle=True)
+        np.save(indexmap_filename, samples_mapping, allow_pickle=True)
         print_rank_0(' > saved the index mapping in {}'.format(
-            indexmap_file_path))
+            indexmap_filename))
         # Make sure all the ranks have built the mapping
         print_rank_0(' > elasped time to build and save samples mapping '
                      '(seconds): {:4f}'.format(
@@ -713,9 +711,9 @@ def get_samples_mapping(indexed_dataset,
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(
-        indexmap_file_path))
+        indexmap_filename))
     start_time = time.time()
-    samples_mapping = np.load(indexmap_file_path, allow_pickle=True, mmap_mode='r')
+    samples_mapping = np.load(indexmap_filename, allow_pickle=True, mmap_mode='r')
     print_rank_0('    loaded indexed file in {:3.3f} seconds'.format(
         time.time() - start_time))
     print_rank_0('    total number of samples: {}'.format(

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -203,8 +203,7 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     np_rng = np.random.RandomState(seed=seed)
 
     # Filename of the index mappings.
-    data_prefix_file_name = Path(data_prefix).name
-    _filename = data_prefix_file_name
+    _filename = Path(data_prefix).name
     _filename += '_{}_indexmap'.format(name)
     _filename += '_{}ns'.format(num_samples)
     _filename += '_{}sl'.format(seq_length)
@@ -214,16 +213,15 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     shuffle_idx_filename = _filename + '_shuffle_idx.npy'
 
     output_folder = Path(get_args().save)
-    doc_idx_file_path = str(output_folder.joinpath(doc_idx_filename).absolute())
-    sample_idx_file_path = str (output_folder.joinpath(sample_idx_filename).absolute())
-    shuffle_idx_file_path = str(output_folder.joinpath(shuffle_idx_filename).absolute())
-
+    doc_idx_filename = output_folder.joinpath(doc_idx_filename).resolve()
+    sample_idx_filename =  output_folder.joinpath(sample_idx_filename).resolve()
+    shuffle_idx_filename = output_folder.joinpath(shuffle_idx_filename).resolve()
 
     # Build the indexed mapping if not exist.
     if torch.distributed.get_rank() == 0:
-        if (not os.path.isfile(doc_idx_file_path)) or \
-           (not os.path.isfile(sample_idx_file_path)) or \
-           (not os.path.isfile(shuffle_idx_file_path)):
+        if (not os.path.isfile(doc_idx_filename)) or \
+           (not os.path.isfile(sample_idx_filename)) or \
+           (not os.path.isfile(shuffle_idx_filename)):
 
             print_rank_0(' > WARNING: could not find index map files, building '
                          'the indices on rank 0 ...')
@@ -270,7 +268,7 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
             start_time = time.time()
             doc_idx = _build_doc_idx(documents, num_epochs, np_rng,
                                      separate_last_epoch)
-            np.save(doc_idx_file_path, doc_idx, allow_pickle=True)
+            np.save(doc_idx_filename, doc_idx, allow_pickle=True)
             print_rank_0(' > elasped time to build and save doc-idx mapping '
                          '(seconds): {:4f}'.format(time.time() - start_time))
             # sample-idx.
@@ -284,7 +282,7 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
                                                   num_epochs, tokens_per_epoch)
             # sample_idx = _build_sample_idx(sizes, doc_idx, seq_length,
             #                               num_epochs, tokens_per_epoch)
-            np.save(sample_idx_file_path, sample_idx, allow_pickle=True)
+            np.save(sample_idx_filename, sample_idx, allow_pickle=True)
             print_rank_0(' > elasped time to build and save sample-idx mapping '
                          '(seconds): {:4f}'.format(time.time() - start_time))
             # shuffle-idx.
@@ -297,7 +295,7 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
                 num_samples_ = sample_idx.shape[0] - 1
             shuffle_idx = _build_shuffle_idx(num_samples_,
                                              sample_idx.shape[0] - 1, np_rng)
-            np.save(shuffle_idx_file_path, shuffle_idx, allow_pickle=True)
+            np.save(shuffle_idx_filename, shuffle_idx, allow_pickle=True)
             print_rank_0(' > elasped time to build and save shuffle-idx mapping'
                          ' (seconds): {:4f}'.format(time.time() - start_time))
 
@@ -314,14 +312,14 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     # Load mappings.
     start_time = time.time()
     print_rank_0(' > loading doc-idx mapping from {}'.format(
-        doc_idx_file_path))
-    doc_idx = np.load(doc_idx_file_path, allow_pickle=True, mmap_mode='r')
+        doc_idx_filename))
+    doc_idx = np.load(doc_idx_filename, allow_pickle=True, mmap_mode='r')
     print_rank_0(' > loading sample-idx mapping from {}'.format(
-        sample_idx_file_path))
-    sample_idx = np.load(sample_idx_file_path, allow_pickle=True, mmap_mode='r')
+        sample_idx_filename))
+    sample_idx = np.load(sample_idx_filename, allow_pickle=True, mmap_mode='r')
     print_rank_0(' > loading shuffle-idx mapping from {}'.format(
-        shuffle_idx_file_path))
-    shuffle_idx = np.load(shuffle_idx_file_path, allow_pickle=True, mmap_mode='r')
+        shuffle_idx_filename))
+    shuffle_idx = np.load(shuffle_idx_filename, allow_pickle=True, mmap_mode='r')
     print_rank_0('    loaded indexed file in {:3.3f} seconds'.format(
         time.time() - start_time))
     print_rank_0('    total number of samples: {}'.format(

--- a/megatron/data/realm_dataset_utils.py
+++ b/megatron/data/realm_dataset_utils.py
@@ -1,5 +1,6 @@
 import os
 import time
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -124,7 +125,8 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         max_num_samples = np.iinfo(np.int64).max - 1
 
     # Filename of the index mapping
-    indexmap_filename = data_prefix
+    data_prefix_file_name = Path(data_prefix).name
+    indexmap_filename = data_prefix_file_name
     indexmap_filename += '_{}_indexmap'.format(name)
     if num_epochs != (np.iinfo(np.int32).max - 1):
         indexmap_filename += '_{}ep'.format(num_epochs)
@@ -136,11 +138,13 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
         indexmap_filename += '_1sentok'
     indexmap_filename += '.npy'
 
+    indexmap_file_path = str(Path(get_args().save).joinpath(indexmap_filename).absolute())
+
     # Build the indexed mapping if not exist.
     if mpu.get_data_parallel_rank() == 0 and \
-            not os.path.isfile(indexmap_filename):
+            not os.path.isfile(indexmap_file_path):
         print(' > WARNING: could not find index map file {}, building '
-              'the indices on rank 0 ...'.format(indexmap_filename))
+              'the indices on rank 0 ...'.format(indexmap_file_path))
 
         # Make sure the types match the helpers input types.
         assert block_dataset.doc_idx.dtype == np.int64
@@ -166,9 +170,9 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
 
 
         print_rank_0(' > done building samples index mapping')
-        np.save(indexmap_filename, mapping_array, allow_pickle=True)
+        np.save(indexmap_file_path, mapping_array, allow_pickle=True)
         print_rank_0(' > saved the index mapping in {}'.format(
-            indexmap_filename))
+            indexmap_file_path))
         # Make sure all the ranks have built the mapping
         print_rank_0(' > elapsed time to build and save samples mapping '
                      '(seconds): {:4f}'.format(
@@ -184,10 +188,10 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(
-        indexmap_filename))
+        indexmap_file_path))
     start_time = time.time()
 
-    mapping_array = np.load(indexmap_filename, allow_pickle=True, mmap_mode='r')
+    mapping_array = np.load(indexmap_file_path, allow_pickle=True, mmap_mode='r')
     samples_mapping = BlockSamplesMapping(mapping_array)
 
     print_rank_0('    loaded indexed file in {:3.3f} seconds'.format(


### PR DESCRIPTION
Tested with bert tiny config:
```
> loading indexed mapping from /mnt/experiments/tmp/amine.elhattami/2021-11-23_11-31-53/wikipedia_20200501.en_dsver_1.13.3-json_BertWordPieceLowerCase_bert-large-uncased-vocab-txt_text_sentence_train_indexmap_503mns_509msl_0.10ssp_1234s.npy       
    loaded indexed file in 0.026 seconds                                                                                                                                                                                                                
    total number of samples: 9712743                                                                                                                                                                                                                    
 > WARNING: could not find index map file /mnt/experiments/tmp/amine.elhattami/2021-11-23_11-31-53/wikipedia_20200501.en_dsver_1.13.3-json_BertWordPieceLowerCase_bert-large-uncased-vocab-txt_text_sentence_valid_indexmap_644mns_509msl_0.10ssp_1234s.
npy, building the indices on rank 0 ...                                                                                                                                                                                                                 
 > building sapmles index mapping for valid ...                                                                                                                                                                                                         
    using uint32 for data mapping...                                                                                                                                                                                                                    
    using:                                                                                                                                                                                                                                              
     number of documents:            6331                                                                                                                                                                                                               
     sentences range:                [125651126, 125733008)                                                                                                                                                                                             
     total number of sentences:      81882                                                                                                                                                                                                              
     number of epochs:               2147483646                                                                                                                                                                                                         
     maximum number of samples:      644                                                                                                                                                                                                                
     maximum sequence length:        509                                                                                                                                                                                                                
     short sequence probability:     0.1                                                                                                                                                                                                                
     short sequence ration (1/prob): 10                                                                                                                                                                                                                 
     seed:                           1234                                                                                                                                                                                                               
    reached 0/644 samples after 0 epochs ...23-11-2021 16-32-45                                                                                                                                                                                         
    reached 644 samples after 1 epochs ...                                                                                                                                                                                                              
   number of empty documents: 0                                                                                                                                                                                                                         
   number of documents with one sentence: 743                                                                                                                                                                                                           
   number of documents with long sentences: 3                                                                                                                                                                                                           
   will create mapping for 7456 samples                                                                                                                                                                                                                 
    reached 0/644 samples after 0 epochs ...23-11-2021 16-32-45                                                                                                                                                                                         
 > done building sapmles index maping                                                                                                                                                                                                                   
 > saved the index mapping in /mnt/experiments/tmp/amine.elhattami/2021-11-23_11-31-53/wikipedia_20200501.en_dsver_1.13.3-json_BertWordPieceLowerCase_bert-large-uncased-vocab-txt_text_sentence_valid_indexmap_644mns_509msl_0.10ssp_1234s.npy         
 > elasped time to build and save samples mapping (seconds): 0.006325                                                                                              
```