### PR TITLE
Measure scales

### DIFF
--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import typing
 
 import torch
 import os
@@ -51,56 +50,3 @@ def is_last_rank():
 
 def print_rank_last(message):
     logger.info(str(message))
-
-_iteration=0
-_metrics={}
-
-def next_iteration(iteration:int):
-    global _iteration, _metrics
-    _metrics={}
-    _iteration=iteration
-
-
-def record_scale(name:str,x:torch.Tensor,grad=True):
-    global _metrics
-    if get_log_scales():
-        _metrics[name]=get_scale(x)
-        if grad and x.requires_grad:
-            x.register_hook(lambda g: record_scale(f"{name}_grad",g,False))
-
-
-def get_scale(x):
-    return x.detach().float().pow(2).mean().pow(0.5)
-
-
-def get_log_scales():
-    args=get_args()
-    return args.log_scales and args.iteration % args.log_interval == 0
-
-
-def log_metrics():
-    metrics = {}
-    for key, value in _metrics.items():
-        metrics_ = metrics
-        keys = key.split(".")
-        for prefix in keys[:-1]:
-            if prefix not in metrics_:
-                metrics_[prefix] = {}
-            metrics_ = metrics_[prefix]
-        metrics_[keys[-1]] = value
-    return metrics
-
-def _log_dicts(self, metrics, indent=0):
-    for key, value in metrics.items():
-        key_ = key.rjust(len(key) + indent)
-        # Merge keys when there is only one entry.
-        while isinstance(value, dict) and len(value) == 1:
-            for value_key, value_ in value.items():
-                key_ = ".".join([key_, value_key])
-                value = value_
-        if isinstance(value, dict):
-            logger.info(key_ + ":")
-            self._log_dicts(value, indent + 2)
-        else:
-            sep = self._config.logging_width - len(value) - len(key_) - 2
-            logger.info(f"{key_.ljust(len(key_)+sep,'.')}  {value}")

--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -39,11 +39,11 @@ if "MEGATRON_SETUP" not in os.environ:
 
 def print_rank_0(message):
     """If distributed is initialized, print only on rank 0."""
-    if torch.distributed.is_initialized():
-        if torch.distributed.get_rank() == 0:
-            print(message, flush=True)
-    else:
-        print(message, flush=True)
+    #if torch.distributed.is_initialized():
+    #    if torch.distributed.get_rank() == 0:
+    #        print(message, flush=True)
+    #else:
+    print(message, flush=True)
 
 def is_last_rank():
     return torch.distributed.get_rank() == (
@@ -51,8 +51,8 @@ def is_last_rank():
 
 def print_rank_last(message):
     """If distributed is initialized, print only on last rank."""
-    if torch.distributed.is_initialized():
-        if is_last_rank():
-            print(message, flush=True)
-    else:
-        print(message, flush=True)
+    #if torch.distributed.is_initialized():
+    #    if is_last_rank():
+    #        print(message, flush=True)
+    #else:
+    print(message, flush=True)

--- a/megatron/__init__.py
+++ b/megatron/__init__.py
@@ -60,10 +60,6 @@ def next_iteration(iteration:int):
     _metrics={}
     _iteration=iteration
 
-def record_metrics(metrics:typing.Dict[str, float]):
-    global _metrics
-    _metrics.update(metrics)
-
 
 def record_scale(name:str,x:torch.Tensor,grad=True):
     global _metrics
@@ -74,11 +70,13 @@ def record_scale(name:str,x:torch.Tensor,grad=True):
 
 
 def get_scale(x):
-    return x.float().pow(2).mean().pow(0.5)
+    return x.detach().float().pow(2).mean().pow(0.5)
+
 
 def get_log_scales():
     args=get_args()
     return args.log_scales and args.iteration % args.log_interval == 0
 
+
 def log_metrics(metrics):
-    logger.info(str({key:value.detach().cpu().item() for key, value in metrics.items()}))
+    logger.info(str({key:value.cpu().item() for key, value in metrics.items()}))

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -19,6 +19,7 @@ import argparse
 import os
 
 import torch
+from megatron import print_rank_0
 
 def parse_args(extra_args_provider=None, defaults={},
                ignore_unknown_args=False):
@@ -73,13 +74,12 @@ def parse_args(extra_args_provider=None, defaults={},
         'size ({})'.format(args.world_size, args.tensor_model_parallel_size,
                            args.pipeline_model_parallel_size)
     args.data_parallel_size = args.world_size // model_parallel_size
-    if args.rank == 0:
-        print('using world size: {}, data-parallel-size: {}, '
-              'tensor-model-parallel size: {}, '
-              'pipeline-model-parallel size: {} '.format(
-                  args.world_size, args.data_parallel_size,
-                  args.tensor_model_parallel_size,
-                  args.pipeline_model_parallel_size), flush=True)
+    print_rank_0('using world size: {}, data-parallel-size: {}, '
+          'tensor-model-parallel size: {}, '
+          'pipeline-model-parallel size: {} '.format(
+              args.world_size, args.data_parallel_size,
+              args.tensor_model_parallel_size,
+              args.pipeline_model_parallel_size))
 
     # Deprecated arguments
     assert args.batch_size is None, '--batch-size argument is no longer ' \
@@ -98,11 +98,9 @@ def parse_args(extra_args_provider=None, defaults={},
         # arguments that are passed to the program. We check this by
         # ensuring the arg is set to None.
         if getattr(args, key) is not None:
-            if args.rank == 0:
-                print('WARNING: overriding default arguments for {key}:{v} \
-                       with {key}:{v2}'.format(key=key, v=defaults[key],
-                                               v2=getattr(args, key)),
-                                               flush=True)
+            print_rank_0('WARNING: overriding default arguments for {key}:{v} \
+                   with {key}:{v2}'.format(key=key, v=defaults[key],
+                                           v2=getattr(args, key)))
         else:
             setattr(args, key, defaults[key])
 
@@ -111,9 +109,8 @@ def parse_args(extra_args_provider=None, defaults={},
     assert args.micro_batch_size > 0
     if args.global_batch_size is None:
         args.global_batch_size = args.micro_batch_size * args.data_parallel_size
-        if args.rank == 0:
-            print('setting global batch size to {}'.format(
-                args.global_batch_size), flush=True)
+        print_rank_0('setting global batch size to {}'.format(
+            args.global_batch_size))
     assert args.global_batch_size > 0
     if args.num_layers_per_virtual_pipeline_stage is not None:
         assert args.pipeline_model_parallel_size > 2, \
@@ -140,13 +137,10 @@ def parse_args(extra_args_provider=None, defaults={},
         # be done in fp32.
         if not args.accumulate_allreduce_grads_in_fp32:
             args.accumulate_allreduce_grads_in_fp32 = True
-            if args.rank == 0:
-                print('accumulate and all-reduce gradients in fp32 for '
-                      'bfloat16 data type.', flush=True)
+            print_rank_0('accumulate and all-reduce gradients in fp32 for '
+                  'bfloat16 data type.')
 
-    if args.rank == 0:
-        print('using {} for parameters ...'.format(args.params_dtype),
-              flush=True)
+    print_rank_0('using {} for parameters ...'.format(args.params_dtype))
 
     # If we do accumulation and all-reduces in fp32, we need to have
     # local DDP and we should set the use-contiguous-buffers-in-ddp.
@@ -239,17 +233,16 @@ def parse_args(extra_args_provider=None, defaults={},
 
 def _print_args(args):
     """Print arguments."""
-    if args.rank == 0:
-        print('------------------------ arguments ------------------------',
-              flush=True)
-        str_list = []
-        for arg in vars(args):
-            dots = '.' * (48 - len(arg))
-            str_list.append('  {} {} {}'.format(arg, dots, getattr(args, arg)))
-        for arg in sorted(str_list, key=lambda x: x.lower()):
-            print(arg, flush=True)
-        print('-------------------- end of arguments ---------------------',
-              flush=True)
+    print_rank_0('------------------------ arguments ------------------------',
+          flush=True)
+    str_list = []
+    for arg in vars(args):
+        dots = '.' * (48 - len(arg))
+        str_list.append('  {} {} {}'.format(arg, dots, getattr(args, arg)))
+    for arg in sorted(str_list, key=lambda x: x.lower()):
+        print_rank_0(arg, flush=True)
+    print_rank_0('-------------------- end of arguments ---------------------',
+          flush=True)
 
 
 def _check_arg_is_not_none(args, arg):

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -304,6 +304,8 @@ def _add_logging_args(parser):
 
     group.add_argument('--log-params-norm', action='store_true',
                        help='If set, calculate and log parameters norm.')
+    group.add_argument('--log-scales', action='store_true',
+                       help='Log the scales of parameters, gradients and activations.')
     group.add_argument('--log-num-zeros-in-grad', action='store_true',
                        help='If set, calculate and log the number of zeros in gradient.')
     group.add_argument('--tensorboard-log-interval', type=int, default=1,

--- a/megatron/data/biencoder_dataset_utils.py
+++ b/megatron/data/biencoder_dataset_utils.py
@@ -189,6 +189,13 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
 
     # Wait until rank 0 generate the index file.
     torch.distributed.barrier(device_ids=[int(os.environ['LOCAL_RANK'])])
+    # It can take some time for the file to be visible on other nodes.
+    for i in range(120):
+        if indexmap_filename.is_file():
+            break
+        if i%10==0:
+            print_rank_0("    Waiting for index file...")
+        time.sleep(1.0)
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -702,6 +702,11 @@ def get_samples_mapping(indexed_dataset,
 
     # Wait until rank 0 generate the index file.
     torch.distributed.barrier(device_ids=[int(os.environ['LOCAL_RANK'])])
+    # It can take some time for the file to be visible on other nodes.
+    for _ in range(120):
+        if indexmap_filename.is_file():
+            break
+        time.sleep(1.0)
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -703,9 +703,11 @@ def get_samples_mapping(indexed_dataset,
     # Wait until rank 0 generate the index file.
     torch.distributed.barrier(device_ids=[int(os.environ['LOCAL_RANK'])])
     # It can take some time for the file to be visible on other nodes.
-    for _ in range(120):
+    for i in range(120):
         if indexmap_filename.is_file():
             break
+        if i%10==0:
+            print_rank_0("    Waiting for index file...")
         time.sleep(1.0)
 
     # Load indexed dataset.

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -302,6 +302,14 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     # Wait until rank 0 generate the index file.
     torch.distributed.barrier(device_ids=[int(os.environ['LOCAL_RANK'])])
 
+    # It can take some time for the file to be visible on other nodes.
+    for i in range(120):
+        if doc_idx_filename.is_file() and sample_idx_filename.is_file() and shuffle_idx_filename.is_file():
+            break
+        if i%10==0:
+            print_rank_0("    Waiting for index files...")
+        time.sleep(1.0)
+
     # Load mappings.
     start_time = time.time()
     print_rank_0(' > loading doc-idx mapping from {}'.format(

--- a/megatron/data/realm_dataset_utils.py
+++ b/megatron/data/realm_dataset_utils.py
@@ -179,6 +179,13 @@ def get_block_samples_mapping(block_dataset, title_dataset, data_prefix, num_epo
 
     # Wait until rank 0 generate the index file.
     torch.distributed.barrier(device_ids=[int(os.environ['LOCAL_RANK'])])
+    # It can take some time for the file to be visible on other nodes.
+    for i in range(120):
+        if indexmap_filename.is_file():
+            break
+        if i%10==0:
+            print_rank_0("    Waiting for index file...")
+        time.sleep(1.0)
 
     # Load indexed dataset.
     print_rank_0(' > loading indexed mapping from {}'.format(

--- a/megatron/fused_kernels/layer_norm_cuda_kernel.cu
+++ b/megatron/fused_kernels/layer_norm_cuda_kernel.cu
@@ -21,7 +21,7 @@
 #include "ATen/ATen.h"
 #include "ATen/AccumulateType.h"
 #include "ATen/cuda/CUDAContext.h"
-#include <THC/THCDeviceUtils.cuh>
+#include "ATen/cuda/DeviceUtils.cuh"
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/megatron/metrics.py
+++ b/megatron/metrics.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 _iteration=0
 _metrics={}
+_LOGGING_WIDTH=50
 
 def next_iteration(iteration:int):
     global _iteration, _metrics
@@ -41,9 +42,10 @@ def log_metrics():
                 metrics_[prefix] = {}
             metrics_ = metrics_[prefix]
         metrics_[keys[-1]] = value
-    return metrics
+    _log_dicts(metrics)
 
-def _log_dicts(self, metrics, indent=0):
+
+def _log_dicts(metrics, indent=0):
     for key, value in metrics.items():
         key_ = key.rjust(len(key) + indent)
         # Merge keys when there is only one entry.
@@ -53,7 +55,7 @@ def _log_dicts(self, metrics, indent=0):
                 value = value_
         if isinstance(value, dict):
             logger.info(key_ + ":")
-            self._log_dicts(value, indent + 2)
+            _log_dicts(value, indent + 2)
         else:
-            sep = self._config.logging_width - len(value) - len(key_) - 2
+            sep = _LOGGING_WIDTH - len(value) - len(key_) - 2
             logger.info(f"{key_.ljust(len(key_)+sep,'.')}  {value}")

--- a/megatron/metrics.py
+++ b/megatron/metrics.py
@@ -16,12 +16,12 @@ def next_iteration(iteration:int):
     _iteration=iteration
 
 
-def record_scale(name:str,x:torch.Tensor,grad=True):
+def record_scale(name:str,x:torch.Tensor,grad=True, bias=None):
     global _metrics
     if get_log_scales():
-        _metrics[name]=get_scale(x)
+        _metrics[f"{name}.scale" if grad else name]=get_scale(x if bias is None else x+bias)
         if grad and x.requires_grad:
-            x.register_hook(lambda g: record_scale(f"{name}_grad",g,False))
+            x.register_hook(lambda g: record_scale(f"{name}.grad",g,False))
 
 
 def get_scale(x):

--- a/megatron/metrics.py
+++ b/megatron/metrics.py
@@ -1,0 +1,59 @@
+import logging
+
+import torch
+from megatron.global_vars import get_args
+
+logger = logging.getLogger(__name__)
+
+_iteration=0
+_metrics={}
+
+def next_iteration(iteration:int):
+    global _iteration, _metrics
+    _metrics={}
+    _iteration=iteration
+
+
+def record_scale(name:str,x:torch.Tensor,grad=True):
+    global _metrics
+    if get_log_scales():
+        _metrics[name]=get_scale(x)
+        if grad and x.requires_grad:
+            x.register_hook(lambda g: record_scale(f"{name}_grad",g,False))
+
+
+def get_scale(x):
+    return x.detach().float().pow(2).mean().pow(0.5)
+
+
+def get_log_scales():
+    args=get_args()
+    return args.log_scales and args.iteration % args.log_interval == 0
+
+
+def log_metrics():
+    metrics = {}
+    for key, value in _metrics.items():
+        metrics_ = metrics
+        keys = key.split(".")
+        for prefix in keys[:-1]:
+            if prefix not in metrics_:
+                metrics_[prefix] = {}
+            metrics_ = metrics_[prefix]
+        metrics_[keys[-1]] = value
+    return metrics
+
+def _log_dicts(self, metrics, indent=0):
+    for key, value in metrics.items():
+        key_ = key.rjust(len(key) + indent)
+        # Merge keys when there is only one entry.
+        while isinstance(value, dict) and len(value) == 1:
+            for value_key, value_ in value.items():
+                key_ = ".".join([key_, value_key])
+                value = value_
+        if isinstance(value, dict):
+            logger.info(key_ + ":")
+            self._log_dicts(value, indent + 2)
+        else:
+            sep = self._config.logging_width - len(value) - len(key_) - 2
+            logger.info(f"{key_.ljust(len(key_)+sep,'.')}  {value}")

--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -72,7 +72,7 @@ class BertLMHead(MegatronModule):
                  layernorm_epsilon, parallel_output, name_=""):
 
         super(BertLMHead, self).__init__()
-        self.name_="output_layer.lm_head"
+        self.name_=name_
 
         args = get_args()
 
@@ -159,13 +159,15 @@ class BertModel(MegatronModule):
             init_method=init_method,
             scaled_init_method=scaled_init_method,
             pre_process=self.pre_process,
-            post_process=self.post_process)
+            post_process=self.post_process,
+            name_=self.name_)
 
         self.initialize_word_embeddings(init_method_normal)
         if self.post_process:
             self.lm_head = BertLMHead(
                 self.word_embeddings_weight().size(0),
-                args.hidden_size, init_method, args.layernorm_epsilon, parallel_output)
+                args.hidden_size, init_method, args.layernorm_epsilon, parallel_output,
+                name_=f"{self.name_}.output_layer.lm_head")
             self._lm_head_key = 'lm_head'
             self.binary_head = None
             if self.add_binary_head:
@@ -173,6 +175,8 @@ class BertModel(MegatronModule):
                                                     init_method, name_=f"{self.name_}.output_layer.sop_head.binary_head")
                 self._binary_head_key = 'binary_head'
 
+        for p in self.parameters():
+            print(getattr(p, "name_", "unknown"), p.shape)
     def set_input_tensor(self, input_tensor):
         """See megatron.model.transformer.set_input_tensor()"""
         self.language_model.set_input_tensor(input_tensor)

--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -94,22 +94,22 @@ class BertLMHead(MegatronModule):
         args=get_args()
         if args.iteration % args.log_interval == 0:
             metrics={}
-            metrics["hidden_scale"]=hidden_states.std()
+            metrics["hidden_scale"]=hidden_states.float().pow(2).mean().pow(0.5)
         hidden_states = self.dense(hidden_states)
         if args.iteration % args.log_interval == 0:
-            metrics["dense_scale"]=hidden_states.std()
+            metrics["dense_scale"]=hidden_states.float().pow(2).mean().pow(0.5)
         hidden_states = self.gelu(hidden_states)
         if args.iteration % args.log_interval == 0:
-            metrics["gelu_scale"]=hidden_states.std()
+            metrics["gelu_scale"]=hidden_states.float().pow(2).mean().pow(0.5)
         hidden_states = self.layernorm(hidden_states)
         if args.iteration % args.log_interval == 0:
-            metrics["ln_scale"]=hidden_states.std()
+            metrics["ln_scale"]=hidden_states.float().pow(2).mean().pow(0.5)
         output = parallel_lm_logits(hidden_states,
                                     word_embeddings_weight,
                                     self.parallel_output,
                                     bias=self.bias)
         if args.iteration % args.log_interval == 0:
-            metrics["logits_scale"]=output.std()
+            metrics["logits_scale"]=output.float().pow(2).mean().pow(0.5)
             print({key:value.detach().cpu().item() for key, value in metrics.items()})
         return output
 
@@ -128,10 +128,10 @@ def post_language_model_processing(lm_output, pooled_output,
         args=get_args()
         if args.iteration % args.log_interval == 0:
             metrics={}
-            metrics["pooled_output"]=pooled_output.std()
+            metrics["pooled_output"]=pooled_output.float().pow(2).mean().pow(0.5)
         binary_logits = binary_head(pooled_output)
         if args.iteration % args.log_interval == 0:
-            metrics["binary_logits"]=binary_logits.std()
+            metrics["binary_logits"]=binary_logits.float().pow(2).mean().pow(0.5)
             print({key:value.detach().cpu().item() for key, value in metrics.items()})
 
     if lm_labels is None:

--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -18,8 +18,9 @@
 import logging
 import torch
 
-from megatron import get_args, record_scale
+from megatron import get_args
 from megatron import mpu
+from megatron.metrics import record_scale
 from megatron.model.enums import AttnMaskType
 from megatron.model.language_model import parallel_lm_logits
 from megatron.model.language_model import get_language_model

--- a/megatron/model/bert_model.py
+++ b/megatron/model/bert_model.py
@@ -77,12 +77,12 @@ class BertLMHead(MegatronModule):
         args = get_args()
 
         self.bias = torch.nn.Parameter(torch.zeros(mpu_vocab_size))
-        self.bias.name_=f"{self.name_}.logits.bias"
+        self.bias.name_=f"{self.name_}.logits.linear_bias"
         mpu.set_tensor_model_parallel_attributes(self.bias, True, 0, 1)
         self.parallel_output = parallel_output
 
         self.dense = get_linear_layer(hidden_size, hidden_size, init_method, name_=f"{self.name_}.dense")
-        self.layernorm = LayerNorm(hidden_size, eps=layernorm_epsilon, name_=f"{self.name_}.layernorm")
+        self.layernorm = LayerNorm(hidden_size, eps=layernorm_epsilon, name_=f"{self.name_}.layer_norm")
         self.gelu = torch.nn.functional.gelu
         if args.openai_gelu:
             self.gelu = openai_gelu
@@ -175,8 +175,6 @@ class BertModel(MegatronModule):
                                                     init_method, name_=f"{self.name_}.output_layer.sop_head.binary_head")
                 self._binary_head_key = 'binary_head'
 
-        for p in self.parameters():
-            print(getattr(p, "name_", "unknown"), p.shape)
     def set_input_tensor(self, input_tensor):
         """See megatron.model.transformer.set_input_tensor()"""
         self.language_model.set_input_tensor(input_tensor)

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -76,9 +76,9 @@ class MixedFusedLayerNorm(torch.nn.Module):
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
         self.weight = Parameter(torch.Tensor(*normalized_shape))
-        self.weight.name_=f"{self.name_}.weight"
+        self.weight.name_=f"{self.name_}.layer_norm_weight"
         self.bias = Parameter(torch.Tensor(*normalized_shape))
-        self.bias.name_=f"{self.name_}.bias"
+        self.bias.name_=f"{self.name_}.layer_norm_bias"
         self.reset_parameters()
 
 

--- a/megatron/model/fused_layer_norm.py
+++ b/megatron/model/fused_layer_norm.py
@@ -23,7 +23,7 @@ from torch.nn.parameter import Parameter
 from torch.nn import init
 import importlib
 
-from megatron import record_scale
+from megatron.metrics import record_scale
 
 global fused_mix_prec_layer_norm_cuda
 fused_mix_prec_layer_norm_cuda = None

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -103,13 +103,13 @@ class Pooler(MegatronModule):
             metrics["pooler_hidden"]=hidden_states.std()
         pooled = hidden_states[:, sequence_index, :]
         if args.iteration % args.log_interval == 0:
-            metrics["pooler_pooled"]=pooled.std()
+            metrics["pooler_pooled"]=pooled.float().pow(2).mean().pow(0.5)
         pooled = self.dense(pooled)
         if args.iteration % args.log_interval == 0:
-            metrics["pooler_dense"]=pooled.std()
+            metrics["pooler_dense"]=pooled.float().pow(2).mean().pow(0.5)
         pooled = torch.tanh(pooled)
         if args.iteration % args.log_interval == 0:
-            metrics["pooler_output"]=pooled.std()
+            metrics["pooler_output"]=pooled.float().pow(2).mean().pow(0.5)
             print({key:value.detach().cpu().item() for key, value in metrics.items()})
         return pooled
 
@@ -199,16 +199,16 @@ class Embedding(MegatronModule):
             metrics={}
         words_embeddings = self.word_embeddings(input_ids)
         if args.iteration % args.log_interval == 0:
-            metrics["words_embeddings"]=words_embeddings.std()
+            metrics["words_embeddings"]=words_embeddings.float().pow(2).mean().pow(0.5)
         position_embeddings = self.position_embeddings(position_ids)
         if args.iteration % args.log_interval == 0:
-            metrics["position_embeddings"]=position_embeddings.std()
+            metrics["position_embeddings"]=position_embeddings.float().pow(2).mean().pow(0.5)
         embeddings = words_embeddings + position_embeddings
         if tokentype_ids is not None:
             assert self.tokentype_embeddings is not None
             tokentype_embeddings=self.tokentype_embeddings(tokentype_ids)
             if args.iteration % args.log_interval == 0:
-                metrics["tokentype_embeddings"]=tokentype_embeddings.std()
+                metrics["tokentype_embeddings"]=tokentype_embeddings.float().pow(2).mean().pow(0.5)
             embeddings = embeddings + tokentype_embeddings
         else:
             assert self.tokentype_embeddings is None
@@ -377,7 +377,7 @@ class TransformerLanguageModel(MegatronModule):
         args=get_args()
         if args.iteration % args.log_interval == 0:
             metrics = {}
-            metrics["encoder_input"] = encoder_input.std()
+            metrics["encoder_input"] = encoder_input.float().pow(2).mean().pow(0.5)
         # encoder.
         if enc_hidden_states is None:
             encoder_output = self.encoder(encoder_input,
@@ -388,7 +388,7 @@ class TransformerLanguageModel(MegatronModule):
             encoder_output = enc_hidden_states.to(encoder_input.dtype)
 
         if args.iteration % args.log_interval == 0:
-            metrics["encoder_output"] = encoder_output.std()
+            metrics["encoder_output"] = encoder_output.float().pow(2).mean().pow(0.5)
             print({key:value.detach().cpu().item() for key, value in metrics.items()})
         if self.post_process:
             if self.add_pooler:

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -48,7 +48,7 @@ def get_language_model(num_tokentypes, add_pooler,
                        encoder_attn_mask_type, init_method=None,
                        scaled_init_method=None, add_decoder=False,
                        decoder_attn_mask_type=AttnMaskType.causal,
-                       pre_process=True, post_process=True):
+                       pre_process=True, post_process=True, name_=""):
     """Build language model and return along with the key to save."""
     args = get_args()
 
@@ -69,7 +69,8 @@ def get_language_model(num_tokentypes, add_pooler,
         decoder_attn_mask_type=decoder_attn_mask_type,
         add_pooler=add_pooler,
         pre_process=pre_process,
-        post_process=post_process
+        post_process=post_process,
+        name_=name_
     )
     # key used for checkpoints.
     language_model_key = 'language_model'
@@ -320,7 +321,8 @@ class TransformerLanguageModel(MegatronModule):
                                        args.max_position_embeddings,
                                        args.hidden_dropout,
                                        self.init_method,
-                                       self.num_tokentypes)
+                                       self.num_tokentypes,
+                                       name_=f"{self.name_}.input_layer")
             self._embedding_key = 'embedding'
 
         # Transformer.

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -18,9 +18,10 @@
 import torch
 import torch.nn.functional as F
 
-from megatron import get_args,record_scale
+from megatron import get_args
 from megatron import mpu
 from .module import MegatronModule
+from megatron.metrics import record_scale
 from megatron.model.enums import LayerType, AttnMaskType
 from megatron.model.transformer import ParallelTransformer
 from megatron.model.utils import get_linear_layer

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -144,14 +144,14 @@ class Embedding(MegatronModule):
             init_method=self.init_method)
         self._word_embeddings_key = 'word_embeddings'
         self.word_embeddings.name_=f"{self.name_}.word_embeddings"
-        self.word_embeddings.weight.name_=f"{self.word_embeddings.name_}.weight"
+        self.word_embeddings.weight.name_=f"{self.word_embeddings.name_}.embedding_weight"
 
         # Position embedding (serial).
         self.position_embeddings = torch.nn.Embedding(
             max_sequence_length, self.hidden_size)
         self._position_embeddings_key = 'position_embeddings'
         self.position_embeddings.name_=f"{self.name_}.position_embeddings"
-        self.position_embeddings.weight.name_=f"{self.position_embeddings.name_}.weight"
+        self.position_embeddings.weight.name_=f"{self.position_embeddings.name_}.embedding_weight"
         # Initialize the position embeddings.
         self.init_method(self.position_embeddings.weight)
 
@@ -164,7 +164,7 @@ class Embedding(MegatronModule):
             self.tokentype_embeddings = torch.nn.Embedding(self.num_tokentypes,
                                                            self.hidden_size)
             self.tokentype_embeddings.name_=f"{self.name_}.tokentype_embeddings"
-            self.tokentype_embeddings.weight.name_=f"{self.tokentype_embeddings.name_}.weight"
+            self.tokentype_embeddings.weight.name_=f"{self.tokentype_embeddings.name_}.embedding_weight"
             # Initialize the token-type embeddings.
             self.init_method(self.tokentype_embeddings.weight)
         else:
@@ -322,7 +322,7 @@ class TransformerLanguageModel(MegatronModule):
                                        args.hidden_dropout,
                                        self.init_method,
                                        self.num_tokentypes,
-                                       name_=f"{self.name_}.input_layer")
+                                       name_=f"{self.name_}.input_layer.embedding")
             self._embedding_key = 'embedding'
 
         # Transformer.

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -178,15 +178,21 @@ class Embedding(MegatronModule):
 
     def forward(self, input_ids, position_ids, tokentype_ids=None):
         # Embeddings.
+        metrics={}
         words_embeddings = self.word_embeddings(input_ids)
+        metrics["words_embeddings"]=words_embeddings.std()
         position_embeddings = self.position_embeddings(position_ids)
+        metrics["position_embeddings"]=position_embeddings.std()
         embeddings = words_embeddings + position_embeddings
         if tokentype_ids is not None:
             assert self.tokentype_embeddings is not None
-            embeddings = embeddings + self.tokentype_embeddings(tokentype_ids)
+            tokentype_embeddings=self.tokentype_embeddings(tokentype_ids)
+            metrics["tokentype_embeddings"]=tokentype_embeddings.std()
+            embeddings = embeddings + tokentype_embeddings
         else:
             assert self.tokentype_embeddings is None
-
+        
+        print({key:value.detach().cpu().item() for key, value in metrics.items()})
         # Dropout.
         embeddings = self.embedding_dropout(embeddings)
 

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -149,7 +149,7 @@ class ParallelAttention(MegatronModule):
                 3 * projection_size,
                 gather_output=False,
                 init_method=init_method,
-                name_=f"layer_{self.name_}.query_key_value")
+                name_=f"{self.name_}.query_key_value")
         else:
             assert attention_type == AttnType.cross_attn
             self.query = mpu.ColumnParallelLinear(
@@ -157,14 +157,14 @@ class ParallelAttention(MegatronModule):
                 projection_size,
                 gather_output=False,
                 init_method=init_method,
-                name_=f"layer_{self.name_}.query")
+                name_=f"{self.name_}.query")
 
             self.key_value = mpu.ColumnParallelLinear(
                 args.hidden_size,
                 2 * projection_size,
                 gather_output=False,
                 init_method=init_method,
-                name_=f"layer_{self.name_}.key_value")
+                name_=f"{self.name_}.key_value")
 
         coeff = None
         self.norm_factor = math.sqrt(self.hidden_size_per_attention_head)
@@ -192,7 +192,7 @@ class ParallelAttention(MegatronModule):
             input_is_parallel=True,
             init_method=output_layer_init_method,
             skip_bias_add=True,
-            name_=f"layer_{self.name_}.dense")
+            name_=f"{self.name_}.dense")
 
     def forward(self, hidden_states, attention_mask, layer_past=None,
                 get_key_value=False, encoder_output=None):
@@ -581,7 +581,7 @@ class ParallelTransformer(MegatronModule):
                 layer_number,
                 layer_type=layer_type,
                 self_attn_mask_type=self_attn_mask_type,
-                name_=f"{self.name_}.layer_{layer_number}")
+                name_=f"{self.name_}.layer_{layer_number-1}")
         if args.virtual_pipeline_model_parallel_size is not None:
             assert args.num_layers % args.virtual_pipeline_model_parallel_size == 0, \
                 'num_layers_per_stage must be divisible by ' \

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -426,7 +426,7 @@ class ParallelTransformerLayer(MegatronModule):
         self.input_layernorm = LayerNorm(
             args.hidden_size,
             eps=args.layernorm_epsilon,
-            name_=f"{self.name_}.input_layernorm",
+            name_=f"{self.name_}.input_layer_norm",
         )
 
         # Self attention.
@@ -444,7 +444,7 @@ class ParallelTransformerLayer(MegatronModule):
         self.post_attention_layernorm = LayerNorm(
             args.hidden_size,
             eps=args.layernorm_epsilon,
-            name_=f"{self.name_}.post_attention_layernorm",
+            name_=f"{self.name_}.post_attention_layer_norm",
         )
 
         if self.layer_type == LayerType.decoder:
@@ -458,7 +458,7 @@ class ParallelTransformerLayer(MegatronModule):
             self.post_inter_attention_layernorm = LayerNorm(
                 args.hidden_size,
                 eps=args.layernorm_epsilon,
-                name_=f"{self.name_}.post_inter_attention_layernorm",
+                name_=f"{self.name_}.post_inter_attention_layer_norm",
             )
 
         # MLP
@@ -634,7 +634,7 @@ class ParallelTransformer(MegatronModule):
             self.final_layernorm = LayerNorm(
                 args.hidden_size,
                 eps=args.layernorm_epsilon,
-                name_=f"{self.name_}.output_layer.final_layernorm")
+                name_=f"{self.name_}.output_layer.final_layer_norm")
 
     def _get_layer(self, layer_number):
         return self.layers[layer_number]

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -56,9 +56,9 @@ def get_linear_layer(rows, columns, init_method, name_=""):
 
     old_forward=layer.forward
 
-    def forward(self,input):
+    def forward(input):
         output=old_forward(input)
-        record_scale(self.name_,output)
+        record_scale(layer.name_,output)
         return output
 
     layer.forward=forward

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -50,8 +50,8 @@ def get_linear_layer(rows, columns, init_method, name_=""):
     with torch.no_grad():
         layer.bias.zero_()
     layer.name_=name_
-    layer.weight.name_=f"{name_}.weight"
-    layer.bias.name_=f"{name_}.bias"
+    layer.weight.name_=f"{name_}.linear_weight"
+    layer.bias.name_=f"{name_}.linear_bias"
 
 
     old_forward=layer.forward

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -31,7 +31,7 @@ def init_method_normal(sigma):
 
 def scaled_init_method_normal(sigma, num_layers):
     """Init method based on N(0, sigma/sqrt(2*num_layers)."""
-    std = sigma / math.sqrt(2.0 * num_layers)
+    std = sigma / math.sqrt(2.0 * max(num_layers,1))
 
     def init_(tensor):
         return torch.nn.init.normal_(tensor, mean=0.0, std=std)

--- a/megatron/model/utils.py
+++ b/megatron/model/utils.py
@@ -18,9 +18,7 @@
 import math
 
 import torch
-from megatron import record_scale
-
-from megatron import get_args
+from megatron.metrics import record_scale
 
 def init_method_normal(sigma):
     """Init method based on N(0, sigma)."""

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -35,7 +35,7 @@ from .random import get_cuda_rng_tracker
 from .utils import divide
 from .utils import split_tensor_along_last_dim
 from .utils import VocabUtility
-from megatron import get_args,record_scale,get_log_scales
+from megatron.metrics import get_args, get_log_scales, record_scale
 
 
 _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {'tensor_model_parallel': False,

--- a/megatron/mpu/layers.py
+++ b/megatron/mpu/layers.py
@@ -35,7 +35,7 @@ from .random import get_cuda_rng_tracker
 from .utils import divide
 from .utils import split_tensor_along_last_dim
 from .utils import VocabUtility
-from megatron import get_args
+from megatron import get_args,record_scale,get_log_scales
 
 
 _MODEL_PARALLEL_ATTRIBUTE_DEFAULTS = {'tensor_model_parallel': False,
@@ -225,8 +225,9 @@ class ColumnParallelLinear(torch.nn.Module):
     def __init__(self, input_size, output_size, bias=True, gather_output=True,
                  init_method=init.xavier_normal_, stride=1,
                  keep_master_weight_for_test=False,
-                 skip_bias_add=False):
+                 skip_bias_add=False,name_=""):
         super(ColumnParallelLinear, self).__init__()
+        self.name_=name_
 
         # Keep input parameters
         self.input_size = input_size
@@ -256,6 +257,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 device=torch.cuda.current_device(), dtype=args.params_dtype))
             _initialize_affine_weight_gpu(self.weight, init_method,
                                           partition_dim=0, stride=stride)
+        self.weight.name_=f"{self.name_}.weight"
             
         if bias:
             if args.use_cpu_initialization:
@@ -270,6 +272,7 @@ class ColumnParallelLinear(torch.nn.Module):
             # Always initialize bias to zero.
             with torch.no_grad():
                 self.bias.zero_()
+            self.bias.name_ = f"{self.name_}.bias"
         else:
             self.register_parameter('bias', None)
 
@@ -288,6 +291,8 @@ class ColumnParallelLinear(torch.nn.Module):
         else:
             output = output_parallel 
         output_bias = self.bias if self.skip_bias_add else None
+        if get_log_scales():
+            record_scale(self.name_, output if output_bias is None else output + output_bias)
         return output, output_bias
 
 
@@ -325,8 +330,9 @@ class RowParallelLinear(torch.nn.Module):
                  input_is_parallel=False,
                  init_method=init.xavier_normal_, stride=1,
                  keep_master_weight_for_test=False,
-                 skip_bias_add=False):
+                 skip_bias_add=False,name_=""):
         super(RowParallelLinear, self).__init__()
+        self.name_=name_
 
         # Keep input parameters
         self.input_size = input_size
@@ -356,6 +362,7 @@ class RowParallelLinear(torch.nn.Module):
                 device=torch.cuda.current_device(), dtype=args.params_dtype))
             _initialize_affine_weight_gpu(self.weight, init_method,
                                           partition_dim=1, stride=stride)
+        self.weight.name_ = f"{self.name_}.weight"
         if bias:
             if args.use_cpu_initialization:
                 self.bias = Parameter(torch.empty(self.output_size,
@@ -367,6 +374,7 @@ class RowParallelLinear(torch.nn.Module):
             # Always initialize bias to zero.
             with torch.no_grad():
                 self.bias.zero_()
+            self.bias.name_ = f"{self.name_}.bias"
         else:
             self.register_parameter('bias', None)
 
@@ -388,5 +396,7 @@ class RowParallelLinear(torch.nn.Module):
         else:
             output = output_
             output_bias = self.bias
+        if get_log_scales():
+            record_scale(self.name_, output if output_bias is None else output + output_bias)
         return output, output_bias
 

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -43,8 +43,6 @@ def _get_params_for_weight_decay_optimization(modules):
                 no_weight_decay_params['params'].extend(
                     [p for n, p in list(module_._parameters.items())
                      if p is not None and n == 'bias'])
-    print("weight_decay_params", [getattr(p, "name_", "unknown") for p in weight_decay_params['params']])
-    print("no_weight_decay_params", [getattr(p, "name_", "unknown") for p in no_weight_decay_params['params']])
 
     return weight_decay_params, no_weight_decay_params
 

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -43,6 +43,8 @@ def _get_params_for_weight_decay_optimization(modules):
                 no_weight_decay_params['params'].extend(
                     [p for n, p in list(module_._parameters.items())
                      if p is not None and n == 'bias'])
+    print("weight_decay_params", [getattr(p, "name_", "unknown") for p in weight_decay_params['params']])
+    print("no_weight_decay_params", [getattr(p, "name_", "unknown") for p in no_weight_decay_params['params']])
 
     return weight_decay_params, no_weight_decay_params
 
@@ -52,6 +54,7 @@ def get_megatron_optimizer(model):
 
     # Base optimizer.
     param_groups = _get_params_for_weight_decay_optimization(model)
+    print("weight_decay", args.weight_decay)
     if args.optimizer == 'adam':
         optimizer = Adam(param_groups,
                          lr=args.lr,

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -13,8 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from apex.optimizers import FusedAdam as Adam
-from apex.optimizers import FusedSGD as SGD
+import warnings
+
+try:
+    from apex.optimizers import FusedAdam as Adam
+    from apex.optimizers import FusedSGD as SGD
+except ImportError:
+    warnings.warn("Apex not found")
 
 from megatron import get_args
 from megatron.model import LayerNorm
@@ -43,11 +48,7 @@ def _get_params_for_weight_decay_optimization(modules):
                 no_weight_decay_params['params'].extend(
                     [p for n, p in list(module_._parameters.items())
                      if p is not None and n == 'bias'])
-    for p in weight_decay_params['params']:
-        print("weight_decay_params",getattr(p, "name_", "unknown"), p.shape)
 
-    for p in no_weight_decay_params['params']:
-        print("no_weight_decay_params",getattr(p, "name_", "unknown"), p.shape)
     return weight_decay_params, no_weight_decay_params
 
 

--- a/megatron/optimizer/__init__.py
+++ b/megatron/optimizer/__init__.py
@@ -43,7 +43,11 @@ def _get_params_for_weight_decay_optimization(modules):
                 no_weight_decay_params['params'].extend(
                     [p for n, p in list(module_._parameters.items())
                      if p is not None and n == 'bias'])
+    for p in weight_decay_params['params']:
+        print("weight_decay_params",getattr(p, "name_", "unknown"), p.shape)
 
+    for p in no_weight_decay_params['params']:
+        print("no_weight_decay_params",getattr(p, "name_", "unknown"), p.shape)
     return weight_decay_params, no_weight_decay_params
 
 

--- a/megatron/optimizer/clip_grads.py
+++ b/megatron/optimizer/clip_grads.py
@@ -63,6 +63,14 @@ def clip_grad_norm_fp32(parameters, max_norm, norm_type=2):
             # Make sure the grads are in fp32
             assert param.grad.type() == 'torch.cuda.FloatTensor'
             grads.append(grad)
+        from megatron import get_args
+        args=get_args()
+        if args.iteration==1:
+            print(grad.shape,
+                  grad_not_none and is_not_shared and is_not_tp_duplicate,
+                  torch.norm(grad, norm_type).detach().cpu().item(),
+                  grad.std().detach().cpu().item()
+                  )
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
             grads_for_norm.append(grad)
 

--- a/megatron/optimizer/clip_grads.py
+++ b/megatron/optimizer/clip_grads.py
@@ -65,12 +65,12 @@ def clip_grad_norm_fp32(parameters, max_norm, norm_type=2):
             grads.append(grad)
         from megatron import get_args
         args=get_args()
-        if args.iteration==1:
-            print(grad.shape,
-                  grad_not_none and is_not_shared and is_not_tp_duplicate,
-                  torch.norm(grad, norm_type).detach().cpu().item(),
-                  grad.std().detach().cpu().item()
-                  )
+        #if args.iteration==1:
+        #    print(grad.shape,
+        #          grad_not_none and is_not_shared and is_not_tp_duplicate,
+        #          torch.norm(grad, norm_type).detach().cpu().item(),
+        #          grad.std().detach().cpu().item()
+        #          )
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
             grads_for_norm.append(grad)
 

--- a/megatron/optimizer/clip_grads.py
+++ b/megatron/optimizer/clip_grads.py
@@ -17,9 +17,13 @@
 
 import torch
 from torch._six import inf
+import warnings
 
-from apex.multi_tensor_apply import multi_tensor_applier
-import amp_C
+try:
+    from apex.multi_tensor_apply import multi_tensor_applier
+    import amp_C
+except ImportError:
+    warnings.warn("Apex not found")
 
 from megatron import mpu
 from megatron.model.module import param_is_not_shared

--- a/megatron/optimizer/clip_grads.py
+++ b/megatron/optimizer/clip_grads.py
@@ -63,14 +63,6 @@ def clip_grad_norm_fp32(parameters, max_norm, norm_type=2):
             # Make sure the grads are in fp32
             assert param.grad.type() == 'torch.cuda.FloatTensor'
             grads.append(grad)
-        from megatron import get_args
-        args=get_args()
-        #if args.iteration==1:
-        #    print(grad.shape,
-        #          grad_not_none and is_not_shared and is_not_tp_duplicate,
-        #          torch.norm(grad, norm_type).detach().cpu().item(),
-        #          grad.std().detach().cpu().item()
-        #          )
         if grad_not_none and is_not_shared and is_not_tp_duplicate:
             grads_for_norm.append(grad)
 

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -25,7 +25,8 @@ import amp_C
 
 from megatron import get_timers
 from megatron import mpu
-from megatron import print_rank_0,record_scale,get_log_scales
+from megatron import print_rank_0
+from megatron.metrics import record_scale,get_log_scales
 
 from .clip_grads import clip_grad_norm_fp32, count_zeros_fp32
 

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -142,8 +142,8 @@ class MegatronOptimizer(ABC):
             for group in self.optimizer.param_groups:
                 for p in group['params']:
                     name_=getattr(p, "name_", "unknown")
-                    record_scale(name_, p, False)
-                    record_scale(f"{name_}_grad", p.grad, False)
+                    record_scale(f"optimizer.{name_}", p, False)
+                    record_scale(f"optimizer.{name_}_grad", p.grad, False)
 
     # Promote state so it can be retrieved or set via
     # "optimizer_instance.state"
@@ -253,6 +253,8 @@ class Float16OptimizerWithFloat16Params(MegatronOptimizer):
                         float16_params_this_group.append(param)
                         # Create a copy
                         main_param = param.detach().clone().float()
+                        if hasattr(param, "name_"):
+                            main_param.name_=param.name_
                         # Copy tensor model parallel attributes.
                         mpu.copy_tensor_model_parallel_attributes(main_param,
                                                                   param)

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -522,8 +522,8 @@ class FP32Optimizer(MegatronOptimizer):
                 for p in group['params']:
                     g=p.grad.detach().float()
                     print(
-                        p.detach().float().std().cpu().item(),
-                        g.std().cpu().item(),
+                        p.detach().float().pow(2).mean().pow(0.5).cpu().item(),
+                        g.detach().float().pow(2).mean().pow(0.5).cpu().item(),
                         torch.norm(g, 2).cpu().item(),
                         getattr(p, "name_", "unknown"),
                         p.shape

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -17,11 +17,15 @@
 
 from abc import ABC
 from abc import abstractmethod
+import warnings
 
 import torch
 
-from apex.multi_tensor_apply import multi_tensor_applier
-import amp_C
+try:
+    from apex.multi_tensor_apply import multi_tensor_applier
+    import amp_C
+except ImportError:
+    warnings.warn("Apex not found")
 
 from megatron import get_timers
 from megatron import mpu
@@ -142,8 +146,8 @@ class MegatronOptimizer(ABC):
             for group in self.optimizer.param_groups:
                 for p in group['params']:
                     name_=getattr(p, "name_", "unknown")
-                    record_scale(f"optimizer.{name_}", p, False)
-                    record_scale(f"optimizer.{name_}_grad", p.grad, False)
+                    record_scale(f"optimizer.{name_}.scale", p, False)
+                    record_scale(f"optimizer.{name_}.grad", p.grad, False)
 
     # Promote state so it can be retrieved or set via
     # "optimizer_instance.state"

--- a/megatron/optimizer/optimizer.py
+++ b/megatron/optimizer/optimizer.py
@@ -406,6 +406,17 @@ class Float16OptimizerWithFloat16Params(MegatronOptimizer):
         num_zeros_in_grad = self.count_zeros() if \
                             self.log_num_zeros_in_grad else None
 
+        from megatron import get_args
+        args=get_args()
+        if args.iteration==1:
+            for group in self.optimizer.param_groups:
+                for p in group['params']:
+                    print(
+                        p.detach().float().std().cpu().item(),
+                        p.grad.detach().float().std().cpu().item(),
+                        getattr(p, "name_", "unknown"),
+                        p.shape
+                    )
         # Step the optimizer.
         self.optimizer.step()
 
@@ -504,6 +515,19 @@ class FP32Optimizer(MegatronOptimizer):
         num_zeros_in_grad = self.count_zeros() if \
                             self.log_num_zeros_in_grad else None
 
+        from megatron import get_args
+        args=get_args()
+        if args.iteration % args.log_interval == 0:
+            for group in self.optimizer.param_groups:
+                for p in group['params']:
+                    g=p.grad.detach().float()
+                    print(
+                        p.detach().float().std().cpu().item(),
+                        g.std().cpu().item(),
+                        torch.norm(g, 2).cpu().item(),
+                        getattr(p, "name_", "unknown"),
+                        p.shape
+                    )
         # Update parameters.
         self.optimizer.step()
 

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -625,6 +625,7 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
                        optimizer,
                        lr_scheduler)
         iteration += 1
+        args.iteration=iteration
         args.consumed_train_samples += mpu.get_data_parallel_world_size() * \
                                        args.micro_batch_size * \
                                        get_num_microbatches()

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -25,7 +25,7 @@ _TRAIN_START_TIME = time.time()
 import torch
 from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
 
-from megatron import get_args, get_log_scales, next_iteration, log_metrics
+from megatron.metrics import get_args, get_log_scales, next_iteration, log_metrics
 from megatron import get_timers
 from megatron import get_tensorboard_writer
 from megatron import get_current_global_batch_size

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -620,6 +620,7 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
     print_datetime('before the start of training step')
     report_memory_flag = True
     while iteration < args.train_iters:
+        next_iteration(iteration)
         update_num_microbatches(args.consumed_train_samples)
         loss_dict, skipped_iter, grad_norm, num_zeros_in_grad = \
             train_step(forward_step_func,
@@ -628,7 +629,6 @@ def train(forward_step_func, model, optimizer, lr_scheduler,
                        optimizer,
                        lr_scheduler)
         iteration += 1
-        next_iteration(iteration)
         args.consumed_train_samples += mpu.get_data_parallel_world_size() * \
                                        args.micro_batch_size * \
                                        get_num_microbatches()


### PR DESCRIPTION
* Fix to allow setting num_layers=0
* Improved logging (log on all workers, use logging module)
* Add an option `--log-scales` to log scales and gradient scales for parameters and activations.
* Give names to parameters  (and some modules). These names match those in LLM so this can be used as a basis for loading LLM parameters/checkpoints, but they are not the same as the Megatron "keys" for state dict which are difficult to follow.
* Fix a bug where the dataset index is not found on some workers (see #2)